### PR TITLE
Implemented NSwag operation processor to elegantly handle documentation

### DIFF
--- a/OpenApiQuery.NSwag/OpenApiQuery.NSwag.csproj
+++ b/OpenApiQuery.NSwag/OpenApiQuery.NSwag.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+      <PackageReference Include="NJsonSchema" Version="10.0.27" />
+      <PackageReference Include="NSwag.Generation" Version="13.1.5" />
+    </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OpenApiQuery\OpenApiQuery.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/OpenApiQuery.NSwag/Processors/OpenApiQueryOperationProcessor.cs
+++ b/OpenApiQuery.NSwag/Processors/OpenApiQueryOperationProcessor.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Namotion.Reflection;
+using NJsonSchema;
+using NJsonSchema.Generation;
+using NSwag;
+using NSwag.Generation.Processors;
+using NSwag.Generation.Processors.Contexts;
+using OpenApiQuery;
+
+namespace OpenApiQuery.NSwag.Processors
+{    
+    public class OpenApiQueryOperationProcessor : IOperationProcessor
+    {
+        private string _notice =
+@"> ### **oData Enabled Action**
+> This controller is enabled for oData filtering. All of the query parameters are optional. If no filter is
+> provided, it will return all matching records (which may have a limit based on the API implementation).
+> For more information about oData filtering, see the following document:
+>
+> https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html";
+
+        Type ResponseType = typeof(OpenApiQueryResult);
+        Type QueryOptionsType = typeof(OpenApiQueryOptions<>);
+        Type ApplyResultType = typeof(OpenApiQueryApplyResult<>);
+        bool _addNotice = false;
+
+
+        /// <summary>
+        /// Construct the operation processor
+        /// </summary>
+        public OpenApiQueryOperationProcessor()
+        {
+        }
+
+        /// <summary>
+        /// Construct the operation processor
+        /// </summary>
+        /// <param name="addDefaultNotice">If true, the default oData notice will be added to all oData enabled operations</param>
+        public OpenApiQueryOperationProcessor(bool addDefaultNotice)
+        {
+            _addNotice = addDefaultNotice;
+        }
+
+        /// <summary>
+        /// Construct the operation processor
+        /// </summary>
+        /// <param name="notice">Notice to add to the top of all oData enabled operations</param>
+        public OpenApiQueryOperationProcessor(string notice)
+        {
+            _notice = notice;
+        }
+
+        public bool Process(OperationProcessorContext context)
+        {
+            MethodInfo opMethod = context.MethodInfo;
+
+            // only affect operations that use the correct response type and also have the correct parameters
+            if (opMethod.ReturnType == ResponseType)
+            {
+                List<ParameterInfo> parameters =
+                    opMethod.GetParameters()
+                            .Where(x => x.ParameterType.IsGenericType == true
+                                     && x.ParameterType.GenericTypeArguments.Count() == 1
+                                     && x.ParameterType.GetGenericTypeDefinition() == QueryOptionsType)
+                            .ToList();
+
+                if (parameters.Count() == 1)
+                {
+                    ParameterInfo queryParameter = parameters[0];
+                    
+                    //
+                    // Here we override the parameters so that instead of it showing an object
+                    // that is required to be passed as a single parameter, it shows each individual
+                    // oData filter parameters as its own parameter.
+                    //
+
+                    IList<OpenApiParameter> opParams = context.OperationDescription.Operation.Parameters;
+                    JsonSchema optionsSchema = opParams[0].ActualSchema;
+                    var props = optionsSchema.InheritedSchema.ActualProperties;
+
+                    opParams.Clear();
+                    foreach (var prop in props)
+                    {
+                        opParams.Add(new OpenApiParameter()
+                        {
+                            Name = prop.Key,
+                            Schema = prop.Value,
+                            Kind = OpenApiParameterKind.Query
+                        });
+                    }
+
+                    
+                    //
+                    // Update the return type to reflect what actually gets written to the body
+                    //
+
+                    // get the generic provided
+                    Type queryType = queryParameter.ParameterType.GenericTypeArguments[0];
+
+                    // generate the generic return type
+                    Type resultType = ApplyResultType.MakeGenericType(new Type[] { queryType });
+
+                    JsonSchema schema = context.SchemaGenerator.Generate(resultType, context.SchemaResolver);
+
+                    IDictionary<string, OpenApiResponse> responses = context.OperationDescription.Operation.Responses;
+
+                    if (responses.Any(x => x.Key == "200"))
+                        responses["200"].Schema = schema;
+
+
+                    //
+                    // optionally set some additional information regarding this operation
+                    //
+                    // Now we add the extra info at the top
+                    if (_addNotice)
+                    {
+                        string opDescription = context.OperationDescription.Operation.Description;
+
+                        if (_notice != null)
+                        {
+                            if (opDescription == null)
+                                opDescription = _notice;
+                            else
+                                opDescription += Environment.NewLine + Environment.NewLine + _notice;
+                        }
+
+                        context.OperationDescription.Operation.Description = opDescription;
+                    }
+                }
+            }
+
+            return true;
+        }
+    }
+
+    public class OpenApiQueryNameGenerator : ISchemaNameGenerator
+    {
+        public string Generate(Type type)
+        {
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(OpenApiQueryOptions<>))
+                return type.Name.Substring(0, type.Name.IndexOf('`'));
+            else
+                return type.Name;
+        }
+    }
+}

--- a/OpenApiQuery.sln
+++ b/OpenApiQuery.sln
@@ -1,10 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+# 
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenApiQuery.Sample", "OpenApiQuery.Sample\OpenApiQuery.Sample.csproj", "{277F0FFD-04A5-4FA0-A0E3-299A4DE1B240}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenApiQuery", "OpenApiQuery\OpenApiQuery.csproj", "{6ADAC419-43A0-437B-AD1E-3E8E8B233D25}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenApiQuery.Test", "OpenApiQuery.Test\OpenApiQuery.Test.csproj", "{111B7733-4DBE-4C73-A7E4-0E5AE01EBF6B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenApiQuery.NSwag", "OpenApiQuery.NSwag\OpenApiQuery.NSwag.csproj", "{4B077D90-013C-4A53-97DF-D6F5773C2123}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -24,5 +27,9 @@ Global
 		{111B7733-4DBE-4C73-A7E4-0E5AE01EBF6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{111B7733-4DBE-4C73-A7E4-0E5AE01EBF6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{111B7733-4DBE-4C73-A7E4-0E5AE01EBF6B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4B077D90-013C-4A53-97DF-D6F5773C2123}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4B077D90-013C-4A53-97DF-D6F5773C2123}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4B077D90-013C-4A53-97DF-D6F5773C2123}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4B077D90-013C-4A53-97DF-D6F5773C2123}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/OpenApiQuery/OpenApiQuery.csproj
+++ b/OpenApiQuery/OpenApiQuery.csproj
@@ -15,7 +15,17 @@
         
     </PropertyGroup>
 
+    <PropertyGroup>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);1591</NoWarn>
+    </PropertyGroup>
+
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="NJsonSchema" Version="10.0.27" />
+    </ItemGroup>
+
 </Project>

--- a/OpenApiQuery/OpenApiQueryApplyResult.cs
+++ b/OpenApiQuery/OpenApiQueryApplyResult.cs
@@ -2,7 +2,15 @@ namespace OpenApiQuery
 {
     public class OpenApiQueryApplyResult<T>
     {
+        /// <summary>
+        /// Total number of items avaailable based on the current filter. Only populated when
+        /// $count=true option is used in filter.
+        /// </summary>
         public long? TotalCount { get; set; }
+
+        /// <summary>
+        /// Object containing the matching items, optionally limited by the $top value provided
+        /// </summary>
         public T[] ResultItems { get; set; }
 
         public OpenApiQueryApplyResult()

--- a/OpenApiQuery/OpenApiQueryOptions.cs
+++ b/OpenApiQuery/OpenApiQueryOptions.cs
@@ -6,24 +6,81 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using System.Runtime.Serialization;
+using NJsonSchema.Annotations;
+using NJsonSchema;
 
 namespace OpenApiQuery
 {
     public abstract class OpenApiQueryOptions
     {
+        /// <summary>
+        /// Not yet implemented
+        /// 
+        /// For implementation status, see: https://github.com/Danielku15/OpenApiQuery/issues/2
+        /// </summary>
+        [JsonSchema(JsonObjectType.String)]
+        [JsonProperty("$select")]
         public SelectQueryOption Select { get; }
+
+        /// <summary>
+        /// Include related navigation properties
+        /// 
+        /// See: https://docs.oasis-open.org/odata/odata/v4.01/csprd06/part2-url-conventions/odata-v4.01-csprd06-part2-url-conventions.html#_Toc21425351
+        /// </summary>
+        [JsonSchema(JsonObjectType.String)]
+        [JsonProperty("$expand")]
         public ExpandQueryOption Expand { get; }
 
+        /// <summary>
+        /// Filter result entities
+        /// 
+        /// See: https://docs.oasis-open.org/odata/odata/v4.01/csprd06/part2-url-conventions/odata-v4.01-csprd06-part2-url-conventions.html#_Toc21425350
+        /// </summary>
+        [JsonSchema(JsonObjectType.String)]
+        [JsonProperty("$filter")]
         public FilterQueryOption Filter { get; }
 
+        /// <summary>
+        /// Specify a custom order the result entities
+        /// 
+        /// See: https://docs.oasis-open.org/odata/odata/v4.01/csprd06/part2-url-conventions/odata-v4.01-csprd06-part2-url-conventions.html#_Toc21425353
+        /// </summary>
+        [JsonSchema(JsonObjectType.String)]
+        [JsonProperty("$orderby")]
         public OrderByQueryOption OrderBy { get; }
 
+        /// <summary>
+        /// Skip N elements in the result set
+        /// 
+        /// See: https://docs.oasis-open.org/odata/odata/v4.01/csprd06/part2-url-conventions/odata-v4.01-csprd06-part2-url-conventions.html#sec_SystemQueryOptionstopandskip
+        /// </summary>
+        [JsonSchema(JsonObjectType.String)]
+        [JsonProperty("$skip")]
         public SkipQueryOption Skip { get; }
 
+
+        /// <summary>
+        /// Select the top N elements in the result set
+        /// 
+        /// See: https://docs.oasis-open.org/odata/odata/v4.01/csprd06/part2-url-conventions/odata-v4.01-csprd06-part2-url-conventions.html#sec_SystemQueryOptionstopandskip
+        /// </summary>
+        [JsonSchema(JsonObjectType.String)]
+        [JsonProperty("$top")]
         public TopQueryOption Top { get; }
 
+
+        /// <summary>
+        /// Provide the total count of items in the data source (with filters applied)
+        /// 
+        /// See: https://docs.oasis-open.org/odata/odata/v4.01/csprd06/part2-url-conventions/odata-v4.01-csprd06-part2-url-conventions.html#sec_SystemQueryOptioncount
+        /// </summary>
+        [JsonSchema(JsonObjectType.Boolean)]
+        [JsonProperty("$count")]
         public CountQueryOption Count { get; }
 
+        [JsonIgnore]
         public Type ElementType { get; }
 
         internal HttpContext HttpContext { get; set; }

--- a/OpenApiQuery/Parsing/QueryExpressionParser.cs
+++ b/OpenApiQuery/Parsing/QueryExpressionParser.cs
@@ -658,8 +658,7 @@ namespace OpenApiQuery.Parsing
                         var member = BindMember(expression, identifier);
                         return System.Linq.Expressions.Expression.MakeMemberAccess(expression, member);
                     }
-
-                    break;
+                    
                 case QueryExpressionTokenKind.OpenParenthesis:
                     return Parenthsis();
                 default:


### PR DESCRIPTION
Added OpenApiQuery.NSwag project with new `OpenApiQueryOperationProcessor()` that can be used with NSwag document generation.

I created it as a separate project so that, if in the future you decide to publish on nuget or something, it can be a different package that depends on the NSwag project.

Additionally, I added a dependency to NJsonSchema so that I could overwrite the property names and types of properties on `OpenApiQueryOptions`.

Example usage:

```
services.AddOpenApiDocument(config =>
{
    config.OperationProcessors.Add(new OpenApiQueryOperationProcessor(true));
});
```

Example output: 

![image](https://user-images.githubusercontent.com/3877800/69186448-86e2fc80-0ae6-11ea-96fa-40a2ee6ae009.png)

![image](https://user-images.githubusercontent.com/3877800/69186499-9b26f980-0ae6-11ea-893f-7ecb76799bbc.png)

Addresses issue #3 