### PR TITLE
Added support for extended $expand features

### DIFF
--- a/OpenApiQuery.Test/Sample/ExpandTests.cs
+++ b/OpenApiQuery.Test/Sample/ExpandTests.cs
@@ -107,6 +107,107 @@ namespace OpenApiQuery.Test.Sample
         }
 
         [TestMethod]
+        public async Task TestExpand_WithExpand_AllOptions()
+        {
+            using var server = SetupSample(new[]
+            {
+                new User
+                {
+                    Blogs = new[]
+                    {
+                        new Blog {Name = "Match1"},
+                        new Blog {Name = "Match2"},
+                        new Blog {Name = "NotMatch3"},
+                        new Blog {Name = "NotMatch4"},
+                        new Blog {Name = "Match5"}
+                    }
+                }
+            });
+            using var client = server.CreateClient();
+
+            var response = await client.GetQueryAsync<User>("/users?$expand=blogs($filter=startsWith(name, 'Match');$orderby=name desc;$skip=1;$top=2)");
+            Assert.AreEqual(1, response.ResultItems.Length);
+            Assert.IsNotNull(response.ResultItems[0].Blogs);
+            Assert.AreEqual("Match2,Match1",
+                string.Join(",", response.ResultItems[0].Blogs.Select(u => u.Name)));
+        }
+
+        [TestMethod]
+        public async Task TestExpand_WithExpand_ExpandOrderBy()
+        {
+            using var server = SetupSample(new[]
+            {
+                new User
+                {
+                    Blogs = new[]
+                    {
+                        new Blog {Name = "D"},
+                        new Blog {Name = "C"},
+                        new Blog {Name = "B"},
+                        new Blog {Name = "A"}
+                    }
+                }
+            });
+            using var client = server.CreateClient();
+
+            var response = await client.GetQueryAsync<User>("/users?$expand=blogs($orderby=name)");
+            Assert.AreEqual(1, response.ResultItems.Length);
+            Assert.IsNotNull(response.ResultItems[0].Blogs);
+            Assert.AreEqual("A,B,C,D",
+                string.Join(",", response.ResultItems[0].Blogs.Select(u => u.Name)));
+        }
+
+        [TestMethod]
+        public async Task TestExpand_WithExpand_ExpandTop()
+        {
+            using var server = SetupSample(new[]
+            {
+                new User
+                {
+                    Blogs = new[]
+                    {
+                        new Blog {Name = "D"},
+                        new Blog {Name = "C"},
+                        new Blog {Name = "B"},
+                        new Blog {Name = "A"}
+                    }
+                }
+            });
+            using var client = server.CreateClient();
+
+            var response = await client.GetQueryAsync<User>("/users?$expand=blogs($top=2)");
+            Assert.AreEqual(1, response.ResultItems.Length);
+            Assert.IsNotNull(response.ResultItems[0].Blogs);
+            Assert.AreEqual("D,C",
+                string.Join(",", response.ResultItems[0].Blogs.Select(u => u.Name)));
+        }
+        
+        [TestMethod]
+        public async Task TestExpand_WithExpand_ExpandSkip()
+        {
+            using var server = SetupSample(new[]
+            {
+                new User
+                {
+                    Blogs = new[]
+                    {
+                        new Blog {Name = "D"},
+                        new Blog {Name = "C"},
+                        new Blog {Name = "B"},
+                        new Blog {Name = "A"}
+                    }
+                }
+            });
+            using var client = server.CreateClient();
+
+            var response = await client.GetQueryAsync<User>("/users?$expand=blogs($skip=2)");
+            Assert.AreEqual(1, response.ResultItems.Length);
+            Assert.IsNotNull(response.ResultItems[0].Blogs);
+            Assert.AreEqual("B,A",
+                string.Join(",", response.ResultItems[0].Blogs.Select(u => u.Name)));
+        }
+
+        [TestMethod]
         public async Task TestExpand_WithExpand_SingleProperty()
         {
             using var server = SetupSample(new[]

--- a/OpenApiQuery/OrderByClause.cs
+++ b/OpenApiQuery/OrderByClause.cs
@@ -1,12 +1,31 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using OpenApiQuery.Utils;
 
 namespace OpenApiQuery
 {
     public class OrderByClause
     {
+        private static readonly MethodInfo OrderByInfo =
+            ReflectionHelper.GetMethod<IEnumerable<object>, IEnumerable<object>>(x => x.OrderBy(y => y == null));
+
+        private static readonly MethodInfo OrderByDescendingInfo =
+            ReflectionHelper.GetMethod<IEnumerable<object>, IEnumerable<object>>(x =>
+                x.OrderByDescending(y => y == null));
+
+        private static readonly MethodInfo ThenByInfo =
+            ReflectionHelper.GetMethod<IOrderedEnumerable<object>, IEnumerable<object>>(x => x.ThenBy(y => y == null));
+
+        private static readonly MethodInfo ThenByDescendingInfo =
+            ReflectionHelper.GetMethod<IOrderedEnumerable<object>, IEnumerable<object>>(x =>
+                x.ThenByDescending(y => y == null));
+
+        private static readonly MethodInfo ApplyToInfo =
+            typeof(OrderByClause).GetMethod(nameof(ApplyToWithKeyType), BindingFlags.Instance | BindingFlags.NonPublic);
+
         public OrderByDirection Direction { get; }
         public Expression Expression { get; }
 
@@ -26,8 +45,38 @@ namespace OpenApiQuery
             return (IQueryable<T>) method.Invoke(this, new object[] {queryable, parameter, isFirstClause});
         }
 
-        private static readonly MethodInfo ApplyToInfo =
-            typeof(OrderByClause).GetMethod(nameof(ApplyToWithKeyType), BindingFlags.Instance | BindingFlags.NonPublic);
+        public Expression ApplyTo(Expression expression, ParameterExpression parameter, bool isFirstClause)
+        {
+            var orderKeyType = Expression.Type;
+            var itemType = parameter.Type;
+
+            MethodInfo sortMethod;
+
+            if (!isFirstClause)
+            {
+                sortMethod = Direction == OrderByDirection.Acending ? ThenByInfo : ThenByDescendingInfo;
+            }
+            else
+            {
+                sortMethod = Direction == OrderByDirection.Acending ? OrderByInfo : OrderByDescendingInfo;
+            }
+
+            sortMethod = sortMethod.MakeGenericMethod(itemType, orderKeyType);
+
+            var funcType = typeof(Func<,>).MakeGenericType(itemType, orderKeyType);
+            var sortLambda = Expression.Lambda(
+                funcType,
+                Expression,
+                parameter
+            );
+
+            expression = Expression.Call(null, sortMethod,
+                expression,
+                sortLambda
+            );
+
+            return expression;
+        }
 
         private IQueryable<T> ApplyToWithKeyType<T, TKey>(IQueryable<T> queryable, ParameterExpression parameter,
             bool isFirstClause)

--- a/OpenApiQuery/Parsing/QueryExpressionParser.cs
+++ b/OpenApiQuery/Parsing/QueryExpressionParser.cs
@@ -651,6 +651,7 @@ namespace OpenApiQuery.Parsing
                             ReportError("Missing close parenthesis after function call");
                             return null;
                         }
+                        NextToken();
 
                         return BindFunctionCall(identifier, arguments);
                     }
@@ -737,7 +738,7 @@ namespace OpenApiQuery.Parsing
                 throw new ParseException(e.Message, Position, e);
             }
         }
-        private static bool IsNumeric(QueryExpressionTokenKind currentQueryExpressionTokenKind)
+        public static bool IsNumeric(QueryExpressionTokenKind currentQueryExpressionTokenKind)
         {
             return currentQueryExpressionTokenKind switch
             {

--- a/OpenApiQuery/SkipQueryOption.cs
+++ b/OpenApiQuery/SkipQueryOption.cs
@@ -1,11 +1,20 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Reflection.Metadata;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using OpenApiQuery.Utils;
 
 namespace OpenApiQuery
 {
     public class SkipQueryOption
     {
+        private static readonly MethodInfo SkipInfo =
+            ReflectionHelper.GetMethod<IEnumerable<object>, IEnumerable<object>>(x => x.Skip(1));
+
         public string RawValue { get; set; }
         public int? Value { get; set; }
 
@@ -15,7 +24,20 @@ namespace OpenApiQuery
             {
                 queryable = queryable.Skip(Value.Value);
             }
+
             return queryable;
+        }
+        public Expression ApplyTo(Expression expression, Type itemType)
+        {
+            if (Value != null)
+            {
+                expression = Expression.Call(null, SkipInfo.MakeGenericMethod(itemType),
+                    expression,
+                    Expression.Constant(Value.Value)
+                );
+            }
+
+            return expression;
         }
 
         public void Initialize(HttpContext httpContext, ModelStateDictionary modelState)
@@ -24,22 +46,27 @@ namespace OpenApiQuery
             {
                 if (values.Count == 1)
                 {
-                    if (int.TryParse(values[0], out var x))
-                    {
-                        RawValue = values[0];
-                        Value = x;
-                    }
-                    else
-                    {
-                        modelState.TryAddModelError("$skip",
-                            "Invalid value specified for $skip, must be number.");
-                    }
+                    Initialize(values[0], modelState);
                 }
                 else
                 {
                     modelState.TryAddModelError("$skip",
                         "Multiple skip clauses found, only one can be specified.");
                 }
+            }
+        }
+
+        public void Initialize(string value, ModelStateDictionary modelState)
+        {
+            if (int.TryParse(value, out var x))
+            {
+                RawValue = value;
+                Value = x;
+            }
+            else
+            {
+                modelState.TryAddModelError("$skip",
+                    "Invalid value specified for $skip, must be number.");
             }
         }
     }

--- a/OpenApiQuery/TopQueryOption.cs
+++ b/OpenApiQuery/TopQueryOption.cs
@@ -1,11 +1,19 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using OpenApiQuery.Utils;
 
 namespace OpenApiQuery
 {
     public class TopQueryOption
     {
+        private static readonly MethodInfo TakeInfo =
+            ReflectionHelper.GetMethod<IEnumerable<object>, IEnumerable<object>>(x => x.Take(1));
+
         public string RawValue { get; set; }
         public int? Value { get; set; }
 
@@ -19,28 +27,47 @@ namespace OpenApiQuery
             return queryable;
         }
 
+        public Expression ApplyTo(Expression expression, Type itemType)
+        {
+            if (Value != null)
+            {
+                expression = Expression.Call(null, TakeInfo.MakeGenericMethod(itemType),
+                    expression,
+                    Expression.Constant(Value.Value)
+                );
+            }
+
+            return expression;
+        }
+
+
         public void Initialize(HttpContext httpContext, ModelStateDictionary modelState)
         {
             if (httpContext.Request.Query.TryGetValue("$top", out var values))
             {
                 if (values.Count == 1)
                 {
-                    if (int.TryParse(values[0], out var x))
-                    {
-                        RawValue = values[0];
-                        Value = x;
-                    }
-                    else
-                    {
-                        modelState.TryAddModelError("$top",
-                            "Invalid value specified for $top, must be number.");
-                    }
+                    Initialize(values[0], modelState);
                 }
                 else
                 {
                     modelState.TryAddModelError("$top",
                         "Multiple top clauses found, only one can be specified.");
                 }
+            }
+        }
+
+        public void Initialize(string value, ModelStateDictionary modelState)
+        {
+            if (int.TryParse(value, out var x))
+            {
+                RawValue = value;
+                Value = x;
+            }
+            else
+            {
+                modelState.TryAddModelError("$top",
+                    "Invalid value specified for $top, must be number.");
             }
         }
     }

--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,11 @@
-# OpenApiQuery 
+# OpenApiQuery
 
-**Disclaimer:** This project is still in a very early proof-of-concept phase and not ready for any production. 
+**Disclaimer:** This project is still in a very early proof-of-concept phase and not ready for any production.
 
-OpenApiQuery is a library inspired by OData to provide an easy way of interacting with your REST API resources. 
+OpenApiQuery is a library inspired by OData to provide an easy way of interacting with your REST API resources.
 It adopts from OData parts of the query syntax as described in the OData specification [OData Version 4.01. Part 2: URL Conventions]( https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html)
 
-The ultimate goal is to support a full OData alike experience with using an OpenAPI specification as replacement for the EDM where needed. Hence the name **OpenApi**Query. 
+The ultimate goal is to support a full OData alike experience with using an OpenAPI specification as replacement for the EDM where needed. Hence the name **OpenApi**Query.
 
 
 ## Framework features
@@ -17,10 +17,9 @@ The ultimate goal is to support a full OData alike experience with using an Open
 | `$expand`           | Include related navigation properties                                         | Supported         |
 | `$expand($filter)`  | Filter related navigation properties which are included                       | Supported         |
 | `$expand($expand)`  | Filter related navigation properties which are included                       | Supported         |
-| `$expand($orderby)` | Apply ordering to the expanded navigation properties                          | Not yet supported |
-| `$expand($skip)`    | Apply paging to the expanded navigation properties                            | Not yet supported |
-| `$expand($top)`     | Apply paging to the expanded navigation properties                            | Not yet supported |
-| `$expand($count)`   | Apply paging to the expanded navigation properties                            | Not yet supported |
+| `$expand($orderby)` | Apply ordering to the expanded navigation properties                          | Supported         |
+| `$expand($skip)`    | Apply paging to the expanded navigation properties                            | Supported         |
+| `$expand($top)`     | Apply paging to the expanded navigation properties                            | Supported         |
 | `$skip`             | Skip N elements in the result set                                             | Supported         |
 | `$top`              | Select the top N elements in the result set                                   | Supported         |
 | `$count`            | Provide the total count of items in the data source (with filters applied)    | Supported         |
@@ -31,54 +30,66 @@ The ultimate goal is to support a full OData alike experience with using an Open
 
 ## OData URL Conventions Compatibility
 
-| Feature                                       | Status |
-| --------------------------------------------- | -------|
-| 3. Service Root URL                           | Not planned                                                                              |
-| 4. Resource Path                              | Not planned                                                                              |
-| **5. Query Options**                          | -                                                                                        |
-| **5.1. System Query Options**                 | Partially Supported                                                                      |
-| **5.1.1 Common Expression Syntax**            | -                                                                                        |
-| 5.1.1.1.1 Equals                              | Supported                                                                                |
-| 5.1.1.1.2 Not Equals                          | Supported                                                                                |
-| 5.1.1.1.3 Greater Than                        | Supported                                                                                |
-| 5.1.1.1.3 Greater Than                        | Supported                                                                                |
-| 5.1.1.1.4 Greater Than or Equal               | Supported                                                                                |
-| 5.1.1.1.5 Less Than                           | Supported                                                                                |
-| 5.1.1.1.6 Less Than or Equal                  | Supported                                                                                |
-| 5.1.1.1.7 And                                 | Supported                                                                                |
-| 5.1.1.1.8 Or                                  | Supported                                                                                |
-| 5.1.1.1.9 Not                                 | Supported                                                                                |
-| 5.1.1.1.10 Has                                | Supported                                                                                |
-| 5.1.1.1.11 In                                 | Supported                                                                                |
-| 5.1.1.2.1 Addition                            | Supported                                                                                |
-| 5.1.1.2.2 Subtraction                         | Supported                                                                                |
-| 5.1.1.2.3 Negation                            | Supported                                                                                |
-| 5.1.1.2.4 Multiplication                      | Supported                                                                                |
-| 5.1.1.2.5 Division                            | Supported                                                                                |
-| 5.1.1.2.6 Modulo                              | Supported                                                                                |
-| 5.1.1.3 Grouping                              | Supported                                                                                |
-| 5.1.1.5.1 concat                              | Partially Supported (string)                                                             |
-| 5.1.1.5.2 contains                            | Partially Supported (string)                                                             |
-| 5.1.1.5.3 endswith                            | Partially Supported (string)                                                             |
-| 5.1.1.5.4 indexof                             | Partially Supported (string)                                                             |
-| 5.1.1.5.5 length                              | Supported                                                                                |
-| 5.1.1.5.6 startswith                          | Partially Supported (string)                                                             |
-| 5.1.1.5.7 substring                           | Partially Supported (string)                                                             |
-| 5.1.1.6 Collection Functions                  | Not yet supported                                                                        |
-| 5.1.1.7 String Functions                      | Not yet supported                                                                        |
-| 5.1.1.8 Date and Time Functions               | Not yet supported                                                                        |
-| 5.1.1.9 Arithmetic Functions                  | Not yet supported                                                                        |
-| 5.1.1.10 Type Functions                       | Not yet supported                                                                        |
-| 5.1.1.11 Geo Functions                        | Not yet supported                                                                        |
-| 5.1.1.12 Conditional Functions                | Not yet supported                                                                        |
-| 5.1.1.13 Lambda Operators                     | Not yet supported                                                                        |
-| 5.1.1.14.1 Primitive Literals                 | Partially Supported (null, bool, int, double, single, string, dateTimeOffset, guid, long |
-| 5.1.1.14.2 Complex and Collection Literals    | Partially Supported (no aliases)                                                         |
-| 5.1.1.14.3 null                               | Supported                                                                                |
-| 5.1.1.14.4 $it                                | Not yet supported                                                                        |
-| 5.1.1.14.5 $root                              | Not yet supported                                                                        |
-| 5.1.1.14.6 $this                              | Not yet supported                                                                        |
-| 5.1.1.15 Path Expressions                     | Supported                                                                                |
-| **5.2. Custom Query Options**                 | Supported                                                                                |
-| **5.3. Parameter Aliases**                    | Not yet supported                                                                        |
-                                                                    
+| Feature                                               | Status |
+| ---------------------------------------------         | -------|
+| 3. Service Root URL                                   | Not planned                                                                              |
+| **4. Resource Path**                                  | All not planned unless mentioned below                                                   |
+| 4.8 Addressing the Count of a Collection              | Not yet supported (only planned for system query options)                                |
+| 4.11 Addressing Derived Types                         | Not yet supported (only planned for system query options)                                |
+| **5. Query Options**                                  | -                                                                                        |
+| **5.1. System Query Options**                         | Partially Supported                                                                      |
+| **5.1.1 Common Expression Syntax**                    | -                                                                                        |
+| 5.1.1.1.1 Equals                                      | Supported                                                                                |
+| 5.1.1.1.2 Not Equals                                  | Supported                                                                                |
+| 5.1.1.1.3 Greater Than                                | Supported                                                                                |
+| 5.1.1.1.3 Greater Than                                | Supported                                                                                |
+| 5.1.1.1.4 Greater Than or Equal                       | Supported                                                                                |
+| 5.1.1.1.5 Less Than                                   | Supported                                                                                |
+| 5.1.1.1.6 Less Than or Equal                          | Supported                                                                                |
+| 5.1.1.1.7 And                                         | Supported                                                                                |
+| 5.1.1.1.8 Or                                          | Supported                                                                                |
+| 5.1.1.1.9 Not                                         | Supported                                                                                |
+| 5.1.1.1.10 Has                                        | Supported                                                                                |
+| 5.1.1.1.11 In                                         | Supported                                                                                |
+| 5.1.1.2.1 Addition                                    | Supported                                                                                |
+| 5.1.1.2.2 Subtraction                                 | Supported                                                                                |
+| 5.1.1.2.3 Negation                                    | Supported                                                                                |
+| 5.1.1.2.4 Multiplication                              | Supported                                                                                |
+| 5.1.1.2.5 Division                                    | Supported                                                                                |
+| 5.1.1.2.6 Modulo                                      | Supported                                                                                |
+| 5.1.1.3 Grouping                                      | Supported                                                                                |
+| 5.1.1.5.1 concat                                      | Partially Supported (string)                                                             |
+| 5.1.1.5.2 contains                                    | Partially Supported (string)                                                             |
+| 5.1.1.5.3 endswith                                    | Partially Supported (string)                                                             |
+| 5.1.1.5.4 indexof                                     | Partially Supported (string)                                                             |
+| 5.1.1.5.5 length                                      | Supported                                                                                |
+| 5.1.1.5.6 startswith                                  | Partially Supported (string)                                                             |
+| 5.1.1.5.7 substring                                   | Partially Supported (string)                                                             |
+| 5.1.1.6 Collection Functions                          | Not yet supported                                                                        |
+| 5.1.1.7 String Functions                              | Not yet supported                                                                        |
+| 5.1.1.8 Date and Time Functions                       | Not yet supported                                                                        |
+| 5.1.1.9 Arithmetic Functions                          | Not yet supported                                                                        |
+| 5.1.1.10 Type Functions                               | Not yet supported                                                                        |
+| 5.1.1.11 Geo Functions                                | Not yet supported                                                                        |
+| 5.1.1.12 Conditional Functions                        | Not yet supported                                                                        |
+| 5.1.1.13 Lambda Operators                             | Not yet supported                                                                        |
+| 5.1.1.14.1 Primitive Literals                         | Partially Supported (null, bool, int, double, single, string, dateTimeOffset, guid, long |
+| 5.1.1.14.2 Complex and Collection Literals            | Partially Supported (no aliases)                                                         |
+| 5.1.1.14.3 null                                       | Supported                                                                                |
+| 5.1.1.14.4 $it                                        | Not yet supported                                                                        |
+| 5.1.1.14.5 $root                                      | Not yet supported                                                                        |
+| 5.1.1.14.6 $this                                      | Not yet supported                                                                        |
+| 5.1.1.15 Path Expressions                             | Supported                                                                                |
+| 5.1.2 System Query Option $filter                     | Supported                                                                                |
+| 5.1.3 System Query Option $expand                     | Supported                                                                                |
+| 5.1.4 System Query Option $select                     | Supported                                                                                |
+| 5.1.5 System Query Option $orderby                    | Supported                                                                                |
+| 5.1.6 System Query Options $top and $skip             | Supported                                                                                |
+| 5.1.7 System Query Option $count                      | Supported                                                                                |
+| 5.1.8 System Query Option $search                     | Not planned                                                                              |
+| 5.1.9 System Query Option $format                     | Not planned                                                                              |
+| 5.1.10 System Query Option $compute                   | Not planned                                                                              |
+| 5.1.11 System Query Option $index                     | Not planned                                                                              |
+| 5.1.12 System Query Option $schemaversion             | Not planned                                                                              |
+| **5.2. Custom Query Options**                         | Supported                                                                                |
+| **5.3. Parameter Aliases**                            | Not yet supported                                                                        |


### PR DESCRIPTION
This PR adds support for the missing $expand options. 

- [x] Reorganized handling of $expand($filter) 
- [x] Added support for $expand($orderby) 
- [x] Added support for $expand($skip)
- [x] Added support for $expand($top)

