### PR TITLE
Fix issues with mongo and non-generic enumerables

### DIFF
--- a/OpenApiQuery/ExpandClause.cs
+++ b/OpenApiQuery/ExpandClause.cs
@@ -135,7 +135,7 @@ namespace OpenApiQuery
                 {
                     // navigation properties that are not expanded, are not loaded
                     // Prop1 = null
-                    //memberBindings.Add(Expression.Bind(property, Expression.Constant(null, property.PropertyType)));
+                    memberBindings.Add(Expression.Bind(property, Expression.Constant(null, property.PropertyType)));
                 }
                 else if (selectAllProperties || select.SelectClauses.ContainsKey(property))
                 {

--- a/OpenApiQuery/ExpandClause.cs
+++ b/OpenApiQuery/ExpandClause.cs
@@ -90,7 +90,7 @@ namespace OpenApiQuery
             SelectClause selectClause,
             IDictionary<PropertyInfo, ExpandClause> expands)
         {
-            var arg = Expression.Parameter(itemType);
+            var arg = Expression.Parameter(itemType, "arg");
             var body = BuildMemberInit(itemType, arg, selectClause, expands);
             var funcType = typeof(Func<,>).MakeGenericType(itemType, itemType);
 
@@ -135,7 +135,7 @@ namespace OpenApiQuery
                 {
                     // navigation properties that are not expanded, are not loaded
                     // Prop1 = null
-                    memberBindings.Add(Expression.Bind(property, Expression.Constant(null, property.PropertyType)));
+                    //memberBindings.Add(Expression.Bind(property, Expression.Constant(null, property.PropertyType)));
                 }
                 else if (selectAllProperties || select.SelectClauses.ContainsKey(property))
                 {

--- a/OpenApiQuery/Utils/ReflectionHelper.cs
+++ b/OpenApiQuery/Utils/ReflectionHelper.cs
@@ -46,6 +46,12 @@ namespace OpenApiQuery.Utils
                 return true;
             }
 
+            if (typeof(System.Collections.IEnumerable).IsAssignableFrom(type))
+            {
+                itemType = typeof(object);
+                return true;
+            }
+
             itemType = null;
             return false;
         }


### PR DESCRIPTION
I couldn't take OData because it doesn't work with netcore 3.0. Your library has capabilities we'd like ot have, but unfortunately it doesn't work with mongodb.

The reason is mongodb driver fails to execute the query if lambda parameter is unnamed.

![image](https://user-images.githubusercontent.com/11201122/70133533-5e870080-1697-11ea-8c58-c4645d16f360.png)


I also enhanced the reflection helper so `IEnumerable` could be considered as collection of `object`s as well.